### PR TITLE
Removed showing of discord.js version

### DIFF
--- a/lib/cmd_help.js
+++ b/lib/cmd_help.js
@@ -3,7 +3,7 @@ module.exports = (config) => {
 
   // TODO: Refactor this mess (it's getting worse)
   const footerString = `Commands: \`${config.prefix}play <category>\`, \`${config.prefix}play advanced\`, \`${config.prefix}help\`, \`${config.prefix}categories\`, \`${config.prefix}stop <#channel>\`, \`${config.prefix}ping\`${typeof config["additional-packages"] !== "undefined" && config["additional-packages"].length !== 0?`\nType '${config.prefix}league help' for league commands.`:""}
-  \n_Bot by [Lake Y](http://lakeys.net). Powered by discord.js ${require("../package.json").dependencies["discord.js"].replace("^","")}${config.databaseURL==="https://opentdb.com"?` and the [Open Trivia Database](https://opentdb.com/).\n${infoFooter}`:""}_`;
+  \n_Bot by [Lake Y](http://lakeys.net). Powered by discord.js${config.databaseURL==="https://opentdb.com"?` and the [Open Trivia Database](https://opentdb.com/).\n${infoFooter}`:"."}_`;
 
   return async function(msg, Database) {
     var res = `Let's play trivia! Type '${config.prefix}play' to start a game.`;


### PR DESCRIPTION
Just an idea, as you are not using always the latest version of discord.js, showing what old version you are using is giving hackers option to check what vulnerabilities are in this bot and they may use them. Also I think showing the exact version is not helping anyone, now it's on your consideration.